### PR TITLE
requirements automatically install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,12 @@ setup(name="libturpial",
     package_data={
         'libturpial': ['certs/*']
     },
+    install_requires=[
+          'setuptools',
+          # -*- Extra requirements: -*-
+          'oauth',
+          'simplejson',
+          'requests',
+    ],
     data_files=data_files,
 )


### PR DESCRIPTION
According to the documentation 
http://pythonhosted.org/distribute/setuptools.html, requirements can be installed automatically
