### PR TITLE
API clean

### DIFF
--- a/libturpial/api/models/account.py
+++ b/libturpial/api/models/account.py
@@ -21,16 +21,16 @@ class Account(object):
     :class:`libturpial.api.models.profile.Profile` model that store the user
     details.
 
-    This is the class you must instanciate if you want to handle/authenticate
+    This is the class you must instantiate if you want to handle/authenticate
     a user account.
 
     *Account* let you perform three actions to build an account: create a new
-    account from scratch, create a new account from params and load a
+    account from scratch, create a new account from parameters and load a
     previously registered account. To create a new account from scratch do:
 
     >>> account = Account.new('twitter')
 
-    If you know the username too, then you can pass it as argument:
+    If you know the user name too, then you can pass it as argument:
 
     >>> account = Account.new('twitter', 'username')
 
@@ -41,16 +41,16 @@ class Account(object):
     >>> url = account.request_oauth_access()
 
     That method will return an URL that your user must visit to authorize the
-    app. After that, you must to ask for the PIN returned by the service and
-    execute:
+    application. After that, you must to ask for the PIN returned by the
+    service and execute:
 
     >>> account.authorize_oauth_access('the_pin')
 
     And voilá! You now have a valid and fully authenticated account ready to be
     registered in :class:`libturpial.api.core.Core`.
 
-    But *Account* let you create accounts passing all the params needed for
-    the OAuth authentication. If you already know those params (user key,
+    But *Account* let you create accounts passing all the parameters needed for
+    the OAuth authentication. If you already know those parameters (user key,
     user secret and PIN) then you just need to execute:
 
     >>> account = Account.new_from_params('twitter', 'username', 'key', \

--- a/libturpial/api/models/account.py
+++ b/libturpial/api/models/account.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import warnings
+
 from libturpial.config import AccountConfig
 from libturpial.api.models.column import Column
 from libturpial.lib.protocols.twitter import twitter
@@ -53,8 +55,8 @@ class Account(object):
     the OAuth authentication. If you already know those parameters (user key,
     user secret and PIN) then you just need to execute:
 
-    >>> account = Account.new_from_params('twitter', 'username', 'key', \
-                                          'secret', 'the_pin')
+    >>> account = Account.new('twitter', 'username', 'key', \
+                              'secret', 'the_pin')
 
     And you will have a valid and fully authenticated account ready to be
     registered in :class:`libturpial.api.core.Core` too.
@@ -69,6 +71,7 @@ class Account(object):
 
     From this point you can use the method described here to handle the
     account object.
+
     """
 
     def __init__(self, protocol_id, username=None):
@@ -97,37 +100,39 @@ class Account(object):
         self.username = username
 
     @staticmethod
-    def new(protocol_id, username=None):
+    def new(protocol_id, username=None, key=None, secret=None):
         """
         Return a new account object associated to the protocol identified by
         *protocol_id*. If *username* is not None it will build the account_id
         for the account.
 
-        This account is empty and must be authenticated before it can be
-        registered in :class:`libturpial.api.core.Core`.
+        If you don't enter the `key` and `secret` parameters this account is
+        empty and must be authenticated before it can be registered
+        in :class:`libturpial.api.core.Core`. Otherwise, this account is
+        authenticated after their creation, so it can be registered in
+        :class:`libturpial.api.core.Core` immediately.
 
         .. warning::
             None information is stored at disk at this point.
+
         """
         account = Account(protocol_id, username)
+        if key and secret:
+            account.setup_user_credentials(account.id_, key, secret)
         return account
 
     @staticmethod
     def new_from_params(protocol_id, username, key, secret, verifier):
         """
-        Return a new account object associated to the protocol identified by
-        *protocol_id* and authenticated against the respective service
-        (Twitter, Identi.ca, etc) using *username*, *key*, *secret* and
-        *verifier* (aka PIN).
+        .. deprecated:: 2.0
 
-        This account is authenticated after creation, so it can be registered
-        in :class:`libturpial.api.core.Core` immediately.
+        Use :method:`new` instead.
 
-        .. warning::
-            None information is stored at disk at this point.
         """
-        account = Account(protocol_id, username)
-        account.setup_user_credentials(account.id_, key, secret)
+        warnings.warn("Shouldn't use this method anymore, please use new",
+                      DeprecationWarning)
+        account = Account.new(protocol_id, username, key, secret)
+
         return account
 
     @staticmethod

--- a/libturpial/api/models/account.py
+++ b/libturpial/api/models/account.py
@@ -126,7 +126,7 @@ class Account(object):
         """
         .. deprecated:: 2.0
 
-        Use :method:`new` instead.
+        Use :meth:`new` instead.
 
         """
         warnings.warn("Shouldn't use this method anymore, please use new",

--- a/tests/models/test_account.py
+++ b/tests/models/test_account.py
@@ -35,10 +35,8 @@ class TestAccount:
         assert isinstance(account, Account)
 
     def test_new_with_params(self, monkeypatch):
-        monkeypatch.setattr('libturpial.api.models.account.Account', DummyAccount)
-
         account = Account.new_from_params('twitter', 'foo', '123', '456', '789')
-        assert isinstance(account, DummyAccount)
+        assert isinstance(account, Account)
 
     def test_load(self, monkeypatch):
         monkeypatch.setattr('libturpial.config.AccountConfig', DummyConfig)

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
 # E231 missing whitespace after ':'
 # E251 unexpected spaces around keyword / parameter equals
 # E261 at least two spaces before inline comment
+# E265 block comment should start with '# '
 # E301 expected 1 blank line
 # E302 expected 2 blank lines
 # E303 too many blank lines
@@ -44,5 +45,5 @@ commands =
 # W391 blank line at end of file
 # W601 .has_key() is deprecated, use 'in'
 show-source = True
-ignore = E126,E128,E231,E251,E261,E301,E302,E303,E501,E711,E712,F401,F403,F821,F841,F999,W291,W391,W601
+ignore = E126,E128,E231,E251,E261,E265,E301,E302,E303,E501,E711,E712,F401,F403,F821,F841,F999,W291,W391,W601
 exclude = .venv,.git,.tox,dist,doc,build,*egg,*shortypython*


### PR DESCRIPTION
I've marked the `new_from_params` method as deprecated, please use instead the `new` method.

I also included the flake8 `E265` error to the "ignore" list, until someone not as lazy as us take the time to fix that crap :bowtie: 
