### PR TITLE
Api Calls failing

### DIFF
--- a/libturpial/exceptions.py
+++ b/libturpial/exceptions.py
@@ -127,3 +127,11 @@ class NotSupported(Exception):
 class SSLRequired(Exception):
     pass
 
+
+class UnlistedException(Exception):
+    def __init__(self, data=None):
+        if data:
+            self.message = 'Status: %(status)s, %(message)s' % data
+        else:
+            self.message = 'Something went wrong'
+

--- a/libturpial/exceptions.py
+++ b/libturpial/exceptions.py
@@ -4,11 +4,14 @@
 class EmptyOAuthCredentials(Exception):
     pass
 
+
 class EmptyBasicCredentials(Exception):
     pass
 
+
 class ErrorCreatingAccount(Exception):
     pass
+
 
 class ErrorLoadingAccount(Exception):
     def __init__(self, message):
@@ -16,79 +19,111 @@ class ErrorLoadingAccount(Exception):
     def __str__(self):
         return repr(self.message)
 
+
 class AccountNotAuthenticated(Exception):
     pass
+
 
 class AccountSuspended(Exception):
     pass
 
+
 class AccountAlreadyRegistered(Exception):
     pass
+
 
 class ColumnAlreadyRegistered(Exception):
     pass
 
+
 class StatusMessageTooLong(Exception):
     pass
+
 
 class StatusDuplicated(Exception):
     pass
 
+
 class ResourceNotFound(Exception):
     pass
+
 
 class UserListNotFound(Exception):
     pass
 
+
 class ServiceOverCapacity(Exception):
     pass
+
 
 class InternalServerError(Exception):
     pass
 
+
 class ServiceDown(Exception):
     pass
+
 
 class InvalidOrMissingCredentials(Exception):
     pass
 
+
 class InvalidOrMissingArguments(Exception):
     pass
+
 
 class ExpressionAlreadyFiltered(Exception):
     pass
 
+
 class BadOAuthTimestamp(Exception):
     pass
 
+
 class ErrorSendingDirectMessage(Exception):
+
     def __init__(self, message):
         self.message = message
+
     def __str__(self):
         return repr(self.message)
+
 
 class RateLimitExceeded(Exception):
     pass
 
+
 class InvalidOAuthToken(Exception):
     pass
 
+
 class URLShortenError(Exception):
+
     def __init__(self, message):
         self.message = message
+
 
 class NoURLToShorten(Exception):
     pass
 
+
 class URLAlreadyShort(Exception):
     pass
 
+
 class PreviewServiceNotSupported(Exception):
     pass
+
 
 class UploadImageError(Exception):
     def __init__(self, message=None):
         self.message = message
 
+
 class NotSupported(Exception):
     pass
+
+
+class ProtocolNotSupported(Exception):
+    pass
+

--- a/libturpial/exceptions.py
+++ b/libturpial/exceptions.py
@@ -124,6 +124,6 @@ class NotSupported(Exception):
     pass
 
 
-class ProtocolNotSupported(Exception):
+class SSLRequired(Exception):
     pass
 

--- a/libturpial/lib/protocols/twitter/twitter.py
+++ b/libturpial/lib/protocols/twitter/twitter.py
@@ -55,6 +55,8 @@ class Main(Protocol):
                 raise RateLimitExceeded
             elif code == 89:
                 raise InvalidOAuthToken
+            elif code == 92:
+                raise ProtocolNotSupported
             elif code == 130 or code == 503 or code == 504:
                 raise ServiceOverCapacity
             elif code == 131 or code == 500:

--- a/libturpial/lib/protocols/twitter/twitter.py
+++ b/libturpial/lib/protocols/twitter/twitter.py
@@ -71,6 +71,8 @@ class Main(Protocol):
                 raise StatusDuplicated
             elif code == 502:
                 raise ServiceDown
+            else:
+                raise UnlistedException(data=response['errors'][0])
 
 
     def initialize_http(self):

--- a/libturpial/lib/protocols/twitter/twitter.py
+++ b/libturpial/lib/protocols/twitter/twitter.py
@@ -22,10 +22,10 @@ class Main(Protocol):
     """Twitter implementation for libturpial"""
     def __init__(self):
         self.id_ = 'twitter'
-        self.base_url = 'http://api.twitter.com/1.1'
-        self.search_url = 'http://api.twitter.com/1.1'
-        self.hashtags_url = 'http://twitter.com/search?q=%23'
-        self.profiles_url = 'http://www.twitter.com'
+        self.base_url = 'https://api.twitter.com/1.1'
+        self.search_url = 'https://api.twitter.com/1.1'
+        self.hashtags_url = 'https://twitter.com/search?q=%23'
+        self.profiles_url = 'https://www.twitter.com'
 
         Protocol.__init__(self)
 


### PR DESCRIPTION
All API calls were failing and during the Quickstart I wasn't able to instantiate Core()

```
{u'errors': [{u'message': u'SSL is required', u'code': 92}]}
```

Changed the twitter urls to https and also created some new exceptions in case this happens again.

@satanas can you code review this, please?
