### PR TITLE
Adds a __str__ and __unicode__ method to the List model

### DIFF
--- a/libturpial/api/models/list.py
+++ b/libturpial/api/models/list.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-class List:
+class List(object):
     """
     This class handles the information about a user list. It receives the
     *id_*, the *user* who owns it, the *name* (also known as slug), the *title*
@@ -30,3 +30,10 @@ class List:
 
     def __repr__(self):
         return "libturpial.api.models.List %s" % (self.id_)
+
+    def __str__(self):
+        return '{user}: {title}'.format(title=self.title, user=self.user.get('screen_name', ''))
+
+    def __unicode__(self):
+        return u'%s' % self.__str__()
+


### PR DESCRIPTION
Here we can discuss also the format for that `__str__` representation of the object.

I took the "declutering exception handling" branch as a base branch because otherwise it would blow.

The format I chose for the string representation of the List model was

`twitter-user: list.title`.

An example could be

`iferminm: Jazz musicians`
