### PR TITLE
Adds a __str__ and __unicode__ method to the Column model

### DIFF
--- a/libturpial/api/core.py
+++ b/libturpial/api/core.py
@@ -154,8 +154,6 @@ class Core(object):
         return self.accman.unregister(account_id, delete_all)
 
     def all_columns(self):
-        # TODO: add __str__ function to libturpial.api.models.column.Column
-        # objects
         """
         Return a dictionary with all columns per account. Example:
 

--- a/libturpial/api/core.py
+++ b/libturpial/api/core.py
@@ -28,7 +28,7 @@ from libturpial.api.managers.accountmanager import AccountManager
 from libturpial.api.managers.columnmanager import ColumnManager
 
 
-class Core:
+class Core(object):
     """
     This is the main object in libturpial. This should be the only class you
     need to instantiate to use libturpial. Most important arguments used in
@@ -69,6 +69,8 @@ class Core:
         *column_id* must be a string ("columnname-username-service")
     """
 
+    #TODO: make this default False, it blows when the token is expired
+    # or at least account loading should be Lazy
     def __init__(self, load_accounts=True):
         self.config = AppConfig()
         self.accman = AccountManager(self.config, load_accounts)

--- a/libturpial/api/models/column.py
+++ b/libturpial/api/models/column.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-class Column:
+class Column(object):
     """
     This model represents a column that holds
     :class:`libturpial.api.models.status.Status` objects. You need to specify
@@ -29,3 +29,9 @@ class Column:
 
     def __repr__(self):
         return "libturpial.api.models.Column %s" % (self.id_)
+
+    def __str__(self):
+        return '%s: %s' % (self.account_id, self.slug)
+
+    def __unicode__(self):
+        return u'%s' % self.__str__()


### PR DESCRIPTION
Here we can discuss also the format for that `__str__` representation of the object.

I took the "declutering exception handling" branch as a base branch because otherwise it would blow.

The format I chose for the string representation of the `List` model was

`account-id: column_slug`

An example could be

`iferminm-twitter: timeline`
