### PR TITLE
Adds __str__ and __unicode__ methods to profile model

### DIFF
--- a/libturpial/api/core.py
+++ b/libturpial/api/core.py
@@ -296,8 +296,6 @@ class Core:
         return account.get_public_timeline(count, since_id)
 
     def get_followers(self, account_id, only_id=False):
-        # TODO: define __str__ function for
-        # in libturpial.api.models.profile.Profile Class
         """
         Returns a :class:`libturpial.api.models.profile.Profile` list with
         all the followers of the account *account_id*

--- a/libturpial/api/models/profile.py
+++ b/libturpial/api/models/profile.py
@@ -58,6 +58,12 @@ class Profile:
     def __repr__(self):
         return "libturpial.api.models.Profile %s" % (self.username)
 
+    def __str__(self):
+        return '%s: %s' % (self.username, self.fullname)
+
+    def __unicode__(self):
+        return u'%s' % self.__str__()
+
     def is_me(self):
         """
         Return `True` if the username of the profile is the same of the


### PR DESCRIPTION
Same as the previous PR, we can discuss the format of the `__str__` and `__unicode__` representation for the `Profile` model

In this case is:

`username: full_name`

For example

`iferminm: Israel Fermín Montilla`
