### PR TITLE
Adds __unicode__ and __str__ methods to Account model

### DIFF
--- a/libturpial/api/core.py
+++ b/libturpial/api/core.py
@@ -361,7 +361,6 @@ class Core:
         return account.update_status(text, in_reply_id, media)
 
     def broadcast_status(self, account_id_array, text):
-        # TODO: add __str__ to libturpial.api.models.account.Account
         """
         Updates all the accounts in account_id_array with the content of *text*
 

--- a/libturpial/api/models/account.py
+++ b/libturpial/api/models/account.py
@@ -91,6 +91,17 @@ class Account(object):
         elif self.protocol_id == Protocol.IDENTICA:
             self.protocol = identica.Main()
 
+    def __str__(self):
+        try:
+            value = self.username
+        except AttributeError:
+            value 'Unknown %s account' % self.protocol
+        finally:
+            return value
+
+    def __unicode__(self):
+        return u'%s' % self.__str__()
+
     def __repr__(self):
         return "libturpial.api.models.Account %s-%s" % (self.username, self.protocol_id)
 


### PR DESCRIPTION
Sames as the previous PRs, we can discuss the format of the **str** and **unicode** representations for the Account model

In this case, if the configuration succeeded, it will show the username

Otherwise, it will show "Unknown (twitter | identica) account"
