### PR TITLE
fixes the failing testcases 

### DIFF
--- a/libturpial/api/models/account.py
+++ b/libturpial/api/models/account.py
@@ -95,7 +95,7 @@ class Account(object):
         try:
             value = self.username
         except AttributeError:
-            value 'Unknown %s account' % self.protocol
+            value = 'Unknown %s account' % self.protocol
         finally:
             return value
 

--- a/tests/models/test_account.py
+++ b/tests/models/test_account.py
@@ -28,7 +28,7 @@ class TestAccount:
         assert isinstance(account.protocol, MainIdentica)
 
     def test_repr(self):
-        assert str(self.account) == "libturpial.api.models.Account foo-twitter"
+        assert repr(self.account) == "libturpial.api.models.Account foo-twitter"
 
     def test_new(self):
         account = Account.new('twitter', 'foo')

--- a/tests/models/test_column.py
+++ b/tests/models/test_column.py
@@ -14,4 +14,4 @@ class TestColumn:
         assert self.column.plural_unit == "tweets"
 
     def test_repr(self):
-        assert str(self.column) == "libturpial.api.models.Column foo-twitter-timeline"
+        assert repr(self.column) == "libturpial.api.models.Column foo-twitter-timeline"

--- a/tests/models/test_list.py
+++ b/tests/models/test_list.py
@@ -22,4 +22,4 @@ class TestColumn:
         assert self.list_.plural_unit == "tweets"
 
     def test_repr(self):
-        assert str(self.list_) == "libturpial.api.models.List foo-twitter-list"
+        assert repr(self.list_) == "libturpial.api.models.List foo-twitter-list"

--- a/tests/models/test_profile.py
+++ b/tests/models/test_profile.py
@@ -38,7 +38,7 @@ class TestProfile:
         assert profile.muted == False
 
     def test_repr(self):
-        assert str(self.profile) == "libturpial.api.models.Profile foo"
+        assert repr(self.profile) == "libturpial.api.models.Profile foo"
 
     def test_is_me(self, monkeypatch):
         assert self.profile.is_me() == True


### PR DESCRIPTION
This should do the trick.

We were testing repr by calling str, now it calls repr().

I'll add an issue regarding str test cases.
