### PR TITLE
Add platform identificators for FreeBSD and DragonFly BSD

### DIFF
--- a/libturpial/common/__init__.py
+++ b/libturpial/common/__init__.py
@@ -12,6 +12,8 @@ from libturpial.lib.services.media.preview import PREVIEW_MEDIA_SERVICES
 NUM_STATUSES = 20
 
 OS_LINUX = 'linux'  #: Constant to identify Linux based operating systems
+OS_FREEBSD = 'freebsd'  #: Constant to identify FreeBSD based operating systems
+OS_DFLY = 'dragonfly'   #: Constant to identify DragonFly BSD based operating systems
 OS_WINDOWS = 'windows'  #: Constant to identify Windows operating systems
 OS_MAC = 'darwin'  #: Constant to identify Mac operating systems
 OS_JAVA = 'java'  #: Constant to identify Java based operating systems

--- a/libturpial/common/tools.py
+++ b/libturpial/common/tools.py
@@ -33,6 +33,10 @@ def detect_os():
     """ Returns a string according to the OS host """
     if sys.platform.startswith('linux'):
         return OS_LINUX
+    elif sys.platform.startswith('freebsd'):
+        return OS_FREEBSD
+    elif sys.platform.startswith('dragonfly'):
+        return OS_DFLY
     elif sys.platform.startswith('win32'):
         return OS_WINDOWS
     elif sys.platform.startswith('darwin'):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -53,6 +53,12 @@ class TestCommon:
         monkeypatch.setattr(sys, 'platform', 'linux')
         assert detect_os() == OS_LINUX
 
+        monkeypatch.setattr(sys, 'platform', 'freebsd')
+        assert detect_os() == OS_FREEBSD
+
+        monkeypatch.setattr(sys, 'platform', 'dragonfly')
+        assert detect_os() == OS_DFLY
+
         monkeypatch.setattr(sys, 'platform', 'win32')
         assert detect_os() == OS_WINDOWS
 


### PR DESCRIPTION
Hello,

We hold this local patches for libturpial in corresponding FreeBSD port, so I'd like to upstream it and remove it from the port. This change adds platform identificators for FreeBSD and DragonFly BSD. Thanks.

Here is the patches in FreeBSD port for the reference: 
http://svnweb.freebsd.org/ports/head/net-im/py-libturpial/files/patch-libturpial__common____init__.py?revision=345665&view=markup
http://svnweb.freebsd.org/ports/head/net-im/py-libturpial/files/patch-libturpial__common__tools.py?revision=345665&view=markup

I also added test case for that.
